### PR TITLE
Support Multiple Geolocations Per Item

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 					</label>
 				</div>
 				<!-- Search Results -->
-				<div id="hits" style="flex: 1;"></div>
+				<div id="hits"></div>
 			</div>
 		</div>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 				<!-- Facets -->
 				<div id="facets">
 					<div id="searchbox"></div>
-					<label class="refine-control">
+					<label id="refine-control" class="refine-control" style="display: none;">
 						<input id="refine-on-move" type="checkbox">
 						Search on Map Move
 					</label>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,15 @@
 		<!-- Include Algolia InstantSearch.js -->
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@8.1.0/themes/reset-min.css" integrity="sha256-2AeJLzExpZvqLUxMfcs+4DWcMwNfpnjUeAAvEtPr0wU=" crossorigin="anonymous">
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@8.1.0/themes/satellite-min.css" integrity="sha256-p/rGN4RGy6EDumyxF9t7LKxWGg6/MZfGhJM/asKkqvA=" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 
-		<script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.22.1/dist/algoliasearch-lite.umd.js" integrity="sha256-pxkGFjfnFWYGOtV9uhCWK/spKiGS0Z7gVDKYm39LyfM=" crossorigin="anonymous"></script>
+		<script
+  src="https://cdn.jsdelivr.net/npm/algoliasearch@4.22.1/dist/algoliasearch-lite.umd.js"
+  integrity="sha256-pxkGFjfnFWYGOtV9uhCWK/spKiGS0Z7gVDKYm39LyfM="
+  crossorigin="anonymous"
+></script>
 		<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.65.0/dist/instantsearch.production.min.js" integrity="sha256-5u4a3JbgF+Ok/p1R8e9iF4nWi4Qs8O1b89pc+8p1UB4=" crossorigin="anonymous"></script>
+ 		<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
 		<!-- Include Stylesheet -->
 		<link rel="stylesheet" type="text/css" href="style.css">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
 	<head>
 		<title>Yoko Algolia Custom Map Widget Test</title>
+		<meta name="viewport" content="width=device-width,initial-scale=1">
 
 		<!-- Include Algolia InstantSearch.js -->
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@8.1.0/themes/reset-min.css" integrity="sha256-2AeJLzExpZvqLUxMfcs+4DWcMwNfpnjUeAAvEtPr0wU=" crossorigin="anonymous">
@@ -25,10 +26,14 @@
 			<!-- Map -->
 			<div id="map">Add Map Here</div>
 
-			<div class="results-and-facets" style="display: flex;">
+			<div class="results-and-facets">
 				<!-- Facets -->
-				<div id="facets" style="max-width: 300px; width: 33.333333%;">
+				<div id="facets">
 					<div id="searchbox"></div>
+					<label class="refine-control">
+						<input id="refine-on-move" type="checkbox">
+						Search on Map Move
+					</label>
 				</div>
 				<!-- Search Results -->
 				<div id="hits" style="flex: 1;"></div>

--- a/index.html
+++ b/index.html
@@ -8,13 +8,9 @@
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@8.1.0/themes/satellite-min.css" integrity="sha256-p/rGN4RGy6EDumyxF9t7LKxWGg6/MZfGhJM/asKkqvA=" crossorigin="anonymous">
 		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 
-		<script
-  src="https://cdn.jsdelivr.net/npm/algoliasearch@4.22.1/dist/algoliasearch-lite.umd.js"
-  integrity="sha256-pxkGFjfnFWYGOtV9uhCWK/spKiGS0Z7gVDKYm39LyfM="
-  crossorigin="anonymous"
-></script>
-		<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.65.0/dist/instantsearch.production.min.js" integrity="sha256-5u4a3JbgF+Ok/p1R8e9iF4nWi4Qs8O1b89pc+8p1UB4=" crossorigin="anonymous"></script>
- 		<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+		<script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.22.1/dist/algoliasearch-lite.umd.js" integrity="sha256-pxkGFjfnFWYGOtV9uhCWK/spKiGS0Z7gVDKYm39LyfM=" crossorigin="anonymous" defer></script>
+		<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.65.0/dist/instantsearch.production.min.js" integrity="sha256-5u4a3JbgF+Ok/p1R8e9iF4nWi4Qs8O1b89pc+8p1UB4=" crossorigin="anonymous" defer></script>
+ 		<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
 
 		<!-- Include Stylesheet -->
 		<link rel="stylesheet" type="text/css" href="style.css">

--- a/script.js
+++ b/script.js
@@ -95,7 +95,7 @@ function init( appId, apiKey, index) {
 		container.querySelector('button').hidden = !currentRefinement;
 
 		markers.forEach(marker => marker.remove());
-
+	
 		markers = items.map(({ _geoloc }) =>
 			L.marker([_geoloc.lat, _geoloc.lng]).addTo(map)
 		);
@@ -120,16 +120,29 @@ function init( appId, apiKey, index) {
 
 	// 3. Instantiate
 	search.addWidgets([
-		customGeoSearch({
-			// instance params
-			items: [],
-			initialPosition: {
-				lat: 13.493493107850682,
-    		lng: -89.38474698770433
-			},
-			initialZoom: 13,
-			container: document.getElementById('map')
-		})
+		customGeoSearch(
+			{
+				container: document.getElementById('map'),
+				initialPosition: {
+					lat: 13.493493107850682,
+					lng: -89.38474698770433
+				},
+				initialZoom: 13,
+				transformItems(items) {
+					const newItems = [];
+					for (let i = 0; i < items.length; i++) {
+						const engineer = items[i];
+						for(let l = 0; l < engineer._geoloc.length; l++) {
+							newItems.push({name: engineer.name, role: engineer.role, objectID: engineer.objectID, _geoloc: {
+								lat: engineer._geoloc[l].lat,
+								lng: engineer._geoloc[l].lng,
+							}});
+						}
+					}
+					return newItems;
+				}
+			}
+		)
 	]);
 
 	search.start();
@@ -142,6 +155,8 @@ document.addEventListener('DOMContentLoaded', function() {
 		const appId = ALGOLIA_APP_ID;
 		const apiKey = ALGOLIA_API_KEY;
 		const index = ALGOLIA_INDEX;
+
+		console.log(appId, apiKey, index);
 
 		// Initialize InstantSearch
 		init(appId, apiKey, index);

--- a/script.js
+++ b/script.js
@@ -60,11 +60,21 @@ function init( appId, apiKey, index) {
 			hasMapMoveSinceLastRefine,
 			widgetParams
 		} = renderOptions;
-		console.log(renderOptions);
+
 		const {
-			initialZoom,
-			initialPosition,
 			container
+  		googleReference,
+  		initialZoom,
+  		initialPosition,
+  		mapOptions,
+  		builtInMarker,
+			customHTMLMarker,
+  		enableRefine,
+  		enableClearMapRefinement,
+  		enableRefineControl,
+  		enableRefineOnMapMove,
+  		templates,
+  		cssClasses
 		} = widgetParams;
 
 		if (isFirstRendering) {
@@ -175,8 +185,6 @@ document.addEventListener('DOMContentLoaded', function() {
 		const appId = ALGOLIA_APP_ID;
 		const apiKey = ALGOLIA_API_KEY;
 		const index = ALGOLIA_INDEX;
-
-		console.log(appId, apiKey, index);
 
 		// Initialize InstantSearch
 		init(appId, apiKey, index);

--- a/script.js
+++ b/script.js
@@ -78,16 +78,21 @@ function init( appId, apiKey, index) {
 		} = widgetParams;
 
 		if (isFirstRendering) {
-			const element = document.querySelector('#map');
-			
-			map = L.map(element);
-
+			// initialize map with Leaflet
+			map = L.map(container);
 			L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				attribution:
 					'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
 			}).addTo(map);
 
-			// refine result set on movement
+			// read refine on move setting if provided
+			if (enableRefineOnMapMove && enableRefineOnMapMove !== isRefineOnMapMove()) {
+				// if the provided setting and the current setting don't match, toggle it
+				toggleRefineOnMapMove();
+			} 
+
+			// refine result set on movement event handler
+			// TODO: consider adding and removing this event when refine on move is toggled
 			map.on('moveend', () => {
 				if (isUserInteraction && isRefineOnMapMove()) {
 					const ne = map.getBounds().getNorthEast();
@@ -100,21 +105,28 @@ function init( appId, apiKey, index) {
 				}
 			});
 			
-			// toggle for refinement on move
-			const refineControl = document.querySelector('#refine-on-move');
-			refineControl.checked = isRefineOnMapMove() ? 'checked' : '';
-			refineControl.addEventListener('change', function(event) {
-				toggleRefineOnMapMove();
-			});
+			// toggle for refinement on move if allowed
+			// check if not false - default is true and it may not be explicitly passed in
+			if (enableRefineControl != false) {
+				const refineControl = document.querySelector('#refine-on-move');
+				refineControl.checked = isRefineOnMapMove() ? 'checked' : '';
+				refineControl.addEventListener('change', function(event) {
+					toggleRefineOnMapMove();
+				});
+				document.querySelector('#refine-control').style.display = 'block'; // show toggle control
+			}
 
-			// reset map button
-			const resetButton = document.createElement('button');
-			resetButton.className = 'map-control map-btn--reset';
-			resetButton.textContent = 'Reset Map';
-			resetButton.addEventListener('click', () => {
-				clearMapRefinement();
-			});
-			container.appendChild(resetButton);
+			// reset map button if resetting refinement is allowed
+			// check if not false - default is true and it may not be explicitly passed in
+			if (enableClearMapRefinement != false) {
+				const resetButton = document.createElement('button');
+				resetButton.className = 'map-control map-btn--reset';
+				resetButton.textContent = 'Reset Map';
+				resetButton.addEventListener('click', () => {
+					clearMapRefinement();
+				});
+				container.appendChild(resetButton);
+			}
 		}
 
 		document.querySelector('button').hidden = !currentRefinement;

--- a/script.js
+++ b/script.js
@@ -62,7 +62,7 @@ function init( appId, apiKey, index) {
 		} = renderOptions;
 
 		const {
-			container
+			container,
   		googleReference,
   		initialZoom,
   		initialPosition,

--- a/style.css
+++ b/style.css
@@ -133,4 +133,8 @@ body {
 	.ais-GeoSearch-map, #map {
 		height: clamp(240px, 50vh, 720px);
 	}
+
+	.results-and-facets {
+		flex-wrap: nowrap;
+	}
 }

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@ body {
 }
 
 #facets {
-	flex: 1 1 33.3333%;
+	flex: 1 1 33.333333%;
 	max-width: 375px;
 	padding: 4px;
 }

--- a/style.css
+++ b/style.css
@@ -1,29 +1,136 @@
+:root {
+	--bg-color: #3170b6;
+	--content-bg-color: #fff;
+	--map-control-border-color: #ccc;
+	--map-control-color: #fff;
+	--map-control-text-color: #111;
+}
+
 body {
-	display: flex;
 	align-items: center;
+	background-color: var(--bg-color);
+	display: flex;
+	font-family: system-ui, sans-serif;
+	font-weight: normal;
 	justify-content: center;
 }
 
 #algolia-search {
-	width: 100%;
-	max-width: 767px;
-	margin: auto;
+	background-color: var(--content-bg-color);
+	border-radius: 4px;
+	box-shadow: 1px 1px 4px rgba(0,0,0,0.325);
+	height: clamp(400px, 90vh, 1800px);
+	margin: 0.5rem auto;
+	max-width: 1280px;
+	padding: 1rem;
+	width: 95%;
 }
 
 .ais-GeoSearch-map, #map {
-	height: 300px; /* You can change this height */
+	height: clamp(240px, 33vh, 720px);
 	margin-bottom: 2rem;
 }
 
-#map:not(.ais-GeoSearch-map) {
-	text-align: center;
+#map:not(.leaflet-container) {
+	align-content: center;
+	align-items: center;
 	border: 10px dashed gray;
 	display: flex;
-	align-content: center;
 	justify-content: center;
-	align-items: center;
+	text-align: center;
+}
+
+.results-and-facets {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+#facets {
+	flex: 1 1 33.3333%;
+	max-width: 375px;
+	padding: 4px;
 }
 
 #hits {
-	padding-left: 1rem;
+	flex: 1 1 66.666667%;
+	max-height: calc(40vh - 3rem);
+  overflow: auto;
+  padding: 4px;
+}
+
+#hits h3 {
+	margin: 0;
+}
+
+#hits p {
+	margin: 0;
+}
+
+.ais-Hits-item {
+	align-items: flex-start;
+	flex-direction: column;
+	padding: 0.875rem 1.25rem;
+}
+
+.ais-Hits--empty {
+	font-size: 1.25rem;
+}
+
+.refine-control {
+	box-shadow: rgba(49, 112, 182, .3) 0 1px 4px 0 inset;
+	display: block;
+  background-color: rgba(0,0,0,.05);
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  padding: 0.5rem 0.75rem;
+}
+
+.refine-control:hover {
+	cursor: pointer;
+}
+
+.refine-control:has(input:checked) {
+	background-color: rgba(49, 112, 182, 0.175);
+	border-color: var(--bg-color);
+	box-shadow: none;
+}
+
+/* map controls */
+.map-control {
+	background-color: var(--map-control-color);
+	border-radius: 3px;
+	border: solid 2px var(--map-control-border-color);
+	color: var(--map-control-text-color);
+	padding: 0.25rem 0.5rem;
+	position: absolute;
+	z-index: 10000;
+}
+
+.map-btn--reset {
+	bottom: 8px;
+	left: 8px;
+}
+
+/* map tooltips */
+.leaflet-tooltip p {
+	margin: 0;
+	text-align: left;
+	white-space: wrap;
+  min-width: 96px;
+}
+
+.map-marker-name {
+	font-size: 0.875rem;
+	font-weight: 700;
+}
+
+.map-marker-role {
+	font-style: italic;
+}
+
+@media screen and (min-width: 768px) {
+	.ais-GeoSearch-map, #map {
+		height: clamp(240px, 50vh, 720px);
+	}
 }


### PR DESCRIPTION
This is a customized version of Algolia's Geosearch widget. It has been updated to support multiple geolocations (map markers) per record in an Algolia index.

It supports many [configuration options](https://www.algolia.com/doc/api-reference/widgets/geo-search/js/), like enabling / disabling refinement controls and options, but not all (e.g. googleReference, mapOptions, cssClasses). Some of the more complex options like cssClasses feel like they should be able to be forwarded to the widget rather than fully reimplemented from scratch, but if that's possible, it wasn't clear to me how. Some of the options were not required to fulfill the defined success criteria, so I didn't spend time on them for this PR.

I didn't test on an actual phone, but I did give the page a responsive layout. The layout assumes this is the whole page — if this were meant to be embedded on another page, I'd rewrite the layout using container queries instead (or auto-sizing with grid).

Please let me know if there are any questions or feedback!